### PR TITLE
fix(schema): map CGameSoundEventName to string, skip CUtlDict

### DIFF
--- a/managed/CounterStrikeSharp.API/Generated/Schema/Classes/CAI_Expresser.g.cs
+++ b/managed/CounterStrikeSharp.API/Generated/Schema/Classes/CAI_Expresser.g.cs
@@ -18,14 +18,6 @@ public partial class CAI_Expresser : NativeObject
 {
     public CAI_Expresser (IntPtr pointer) : base(pointer) {}
 
-	// m_conceptCooldowns
-	[SchemaMember("CAI_Expresser", "m_conceptCooldowns")]
-	public CUtlDict<GameTime_t> ConceptCooldowns => Schema.GetDeclaredClass<CUtlDict<GameTime_t>>(this.Handle, "CAI_Expresser", "m_conceptCooldowns");
-
-	// m_ruleCooldowns
-	[SchemaMember("CAI_Expresser", "m_ruleCooldowns")]
-	public CUtlDict<GameTime_t> RuleCooldowns => Schema.GetDeclaredClass<CUtlDict<GameTime_t>>(this.Handle, "CAI_Expresser", "m_ruleCooldowns");
-
 	// m_flStopTalkTime
 	[SchemaMember("CAI_Expresser", "m_flStopTalkTime")]
 	public ref float StopTalkTime => ref Schema.GetRef<float>(this.Handle, "CAI_Expresser", "m_flStopTalkTime");

--- a/managed/CounterStrikeSharp.API/Generated/Schema/Classes/CAmbientGeneric.g.cs
+++ b/managed/CounterStrikeSharp.API/Generated/Schema/Classes/CAmbientGeneric.g.cs
@@ -44,7 +44,11 @@ public partial class CAmbientGeneric : CPointEntity
 
 	// m_iszSound
 	[SchemaMember("CAmbientGeneric", "m_iszSound")]
-	public CGameSoundEventName Sound => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CAmbientGeneric", "m_iszSound");
+	public string Sound
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CAmbientGeneric", "m_iszSound"); }
+		set { Schema.SetString(this.Handle, "CAmbientGeneric", "m_iszSound", value); }
+	}
 
 	// m_sSourceEntName
 	[SchemaMember("CAmbientGeneric", "m_sSourceEntName")]

--- a/managed/CounterStrikeSharp.API/Generated/Schema/Classes/CBaseButton.g.cs
+++ b/managed/CounterStrikeSharp.API/Generated/Schema/Classes/CBaseButton.g.cs
@@ -36,15 +36,27 @@ public partial class CBaseButton : CBaseToggle
 
 	// m_sUseSound
 	[SchemaMember("CBaseButton", "m_sUseSound")]
-	public CGameSoundEventName UseSound => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CBaseButton", "m_sUseSound");
+	public string UseSound
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CBaseButton", "m_sUseSound"); }
+		set { Schema.SetString(this.Handle, "CBaseButton", "m_sUseSound", value); }
+	}
 
 	// m_sLockedSound
 	[SchemaMember("CBaseButton", "m_sLockedSound")]
-	public CGameSoundEventName LockedSound => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CBaseButton", "m_sLockedSound");
+	public string LockedSound
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CBaseButton", "m_sLockedSound"); }
+		set { Schema.SetString(this.Handle, "CBaseButton", "m_sLockedSound", value); }
+	}
 
 	// m_sUnlockedSound
 	[SchemaMember("CBaseButton", "m_sUnlockedSound")]
-	public CGameSoundEventName UnlockedSound => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CBaseButton", "m_sUnlockedSound");
+	public string UnlockedSound
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CBaseButton", "m_sUnlockedSound"); }
+		set { Schema.SetString(this.Handle, "CBaseButton", "m_sUnlockedSound", value); }
+	}
 
 	// m_sOverrideAnticipationName
 	[SchemaMember("CBaseButton", "m_sOverrideAnticipationName")]

--- a/managed/CounterStrikeSharp.API/Generated/Schema/Classes/CBaseDoor.g.cs
+++ b/managed/CounterStrikeSharp.API/Generated/Schema/Classes/CBaseDoor.g.cs
@@ -60,19 +60,35 @@ public partial class CBaseDoor : CBaseToggle
 
 	// m_NoiseMoving
 	[SchemaMember("CBaseDoor", "m_NoiseMoving")]
-	public CGameSoundEventName NoiseMoving => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CBaseDoor", "m_NoiseMoving");
+	public string NoiseMoving
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CBaseDoor", "m_NoiseMoving"); }
+		set { Schema.SetString(this.Handle, "CBaseDoor", "m_NoiseMoving", value); }
+	}
 
 	// m_NoiseArrived
 	[SchemaMember("CBaseDoor", "m_NoiseArrived")]
-	public CGameSoundEventName NoiseArrived => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CBaseDoor", "m_NoiseArrived");
+	public string NoiseArrived
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CBaseDoor", "m_NoiseArrived"); }
+		set { Schema.SetString(this.Handle, "CBaseDoor", "m_NoiseArrived", value); }
+	}
 
 	// m_NoiseMovingClosed
 	[SchemaMember("CBaseDoor", "m_NoiseMovingClosed")]
-	public CGameSoundEventName NoiseMovingClosed => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CBaseDoor", "m_NoiseMovingClosed");
+	public string NoiseMovingClosed
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CBaseDoor", "m_NoiseMovingClosed"); }
+		set { Schema.SetString(this.Handle, "CBaseDoor", "m_NoiseMovingClosed", value); }
+	}
 
 	// m_NoiseArrivedClosed
 	[SchemaMember("CBaseDoor", "m_NoiseArrivedClosed")]
-	public CGameSoundEventName NoiseArrivedClosed => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CBaseDoor", "m_NoiseArrivedClosed");
+	public string NoiseArrivedClosed
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CBaseDoor", "m_NoiseArrivedClosed"); }
+		set { Schema.SetString(this.Handle, "CBaseDoor", "m_NoiseArrivedClosed", value); }
+	}
 
 	// m_ChainTarget
 	[SchemaMember("CBaseDoor", "m_ChainTarget")]

--- a/managed/CounterStrikeSharp.API/Generated/Schema/Classes/CBasePlatTrain.g.cs
+++ b/managed/CounterStrikeSharp.API/Generated/Schema/Classes/CBasePlatTrain.g.cs
@@ -20,11 +20,19 @@ public partial class CBasePlatTrain : CBaseToggle
 
 	// m_NoiseMoving
 	[SchemaMember("CBasePlatTrain", "m_NoiseMoving")]
-	public CGameSoundEventName NoiseMoving => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CBasePlatTrain", "m_NoiseMoving");
+	public string NoiseMoving
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CBasePlatTrain", "m_NoiseMoving"); }
+		set { Schema.SetString(this.Handle, "CBasePlatTrain", "m_NoiseMoving", value); }
+	}
 
 	// m_NoiseArrived
 	[SchemaMember("CBasePlatTrain", "m_NoiseArrived")]
-	public CGameSoundEventName NoiseArrived => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CBasePlatTrain", "m_NoiseArrived");
+	public string NoiseArrived
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CBasePlatTrain", "m_NoiseArrived"); }
+		set { Schema.SetString(this.Handle, "CBasePlatTrain", "m_NoiseArrived", value); }
+	}
 
 	// m_volume
 	[SchemaMember("CBasePlatTrain", "m_volume")]

--- a/managed/CounterStrikeSharp.API/Generated/Schema/Classes/CBasePropDoor.g.cs
+++ b/managed/CounterStrikeSharp.API/Generated/Schema/Classes/CBasePropDoor.g.cs
@@ -84,39 +84,75 @@ public partial class CBasePropDoor : CDynamicProp
 
 	// m_SoundMoving
 	[SchemaMember("CBasePropDoor", "m_SoundMoving")]
-	public CGameSoundEventName SoundMoving => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CBasePropDoor", "m_SoundMoving");
+	public string SoundMoving
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CBasePropDoor", "m_SoundMoving"); }
+		set { Schema.SetString(this.Handle, "CBasePropDoor", "m_SoundMoving", value); }
+	}
 
 	// m_SoundOpen
 	[SchemaMember("CBasePropDoor", "m_SoundOpen")]
-	public CGameSoundEventName SoundOpen => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CBasePropDoor", "m_SoundOpen");
+	public string SoundOpen
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CBasePropDoor", "m_SoundOpen"); }
+		set { Schema.SetString(this.Handle, "CBasePropDoor", "m_SoundOpen", value); }
+	}
 
 	// m_SoundClose
 	[SchemaMember("CBasePropDoor", "m_SoundClose")]
-	public CGameSoundEventName SoundClose => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CBasePropDoor", "m_SoundClose");
+	public string SoundClose
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CBasePropDoor", "m_SoundClose"); }
+		set { Schema.SetString(this.Handle, "CBasePropDoor", "m_SoundClose", value); }
+	}
 
 	// m_SoundLock
 	[SchemaMember("CBasePropDoor", "m_SoundLock")]
-	public CGameSoundEventName SoundLock => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CBasePropDoor", "m_SoundLock");
+	public string SoundLock
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CBasePropDoor", "m_SoundLock"); }
+		set { Schema.SetString(this.Handle, "CBasePropDoor", "m_SoundLock", value); }
+	}
 
 	// m_SoundUnlock
 	[SchemaMember("CBasePropDoor", "m_SoundUnlock")]
-	public CGameSoundEventName SoundUnlock => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CBasePropDoor", "m_SoundUnlock");
+	public string SoundUnlock
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CBasePropDoor", "m_SoundUnlock"); }
+		set { Schema.SetString(this.Handle, "CBasePropDoor", "m_SoundUnlock", value); }
+	}
 
 	// m_SoundLatch
 	[SchemaMember("CBasePropDoor", "m_SoundLatch")]
-	public CGameSoundEventName SoundLatch => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CBasePropDoor", "m_SoundLatch");
+	public string SoundLatch
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CBasePropDoor", "m_SoundLatch"); }
+		set { Schema.SetString(this.Handle, "CBasePropDoor", "m_SoundLatch", value); }
+	}
 
 	// m_SoundPound
 	[SchemaMember("CBasePropDoor", "m_SoundPound")]
-	public CGameSoundEventName SoundPound => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CBasePropDoor", "m_SoundPound");
+	public string SoundPound
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CBasePropDoor", "m_SoundPound"); }
+		set { Schema.SetString(this.Handle, "CBasePropDoor", "m_SoundPound", value); }
+	}
 
 	// m_SoundJiggle
 	[SchemaMember("CBasePropDoor", "m_SoundJiggle")]
-	public CGameSoundEventName SoundJiggle => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CBasePropDoor", "m_SoundJiggle");
+	public string SoundJiggle
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CBasePropDoor", "m_SoundJiggle"); }
+		set { Schema.SetString(this.Handle, "CBasePropDoor", "m_SoundJiggle", value); }
+	}
 
 	// m_SoundLockedAnim
 	[SchemaMember("CBasePropDoor", "m_SoundLockedAnim")]
-	public CGameSoundEventName SoundLockedAnim => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CBasePropDoor", "m_SoundLockedAnim");
+	public string SoundLockedAnim
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CBasePropDoor", "m_SoundLockedAnim"); }
+		set { Schema.SetString(this.Handle, "CBasePropDoor", "m_SoundLockedAnim", value); }
+	}
 
 	// m_numCloseAttempts
 	[SchemaMember("CBasePropDoor", "m_numCloseAttempts")]

--- a/managed/CounterStrikeSharp.API/Generated/Schema/Classes/CEnvSoundscape.g.cs
+++ b/managed/CounterStrikeSharp.API/Generated/Schema/Classes/CEnvSoundscape.g.cs
@@ -28,7 +28,11 @@ public partial class CEnvSoundscape : CBaseEntity
 
 	// m_soundEventName
 	[SchemaMember("CEnvSoundscape", "m_soundEventName")]
-	public CGameSoundEventName SoundEventName => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CEnvSoundscape", "m_soundEventName");
+	public string SoundEventName
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CEnvSoundscape", "m_soundEventName"); }
+		set { Schema.SetString(this.Handle, "CEnvSoundscape", "m_soundEventName", value); }
+	}
 
 	// m_bOverrideWithEvent
 	[SchemaMember("CEnvSoundscape", "m_bOverrideWithEvent")]

--- a/managed/CounterStrikeSharp.API/Generated/Schema/Classes/CFuncMoveLinear.g.cs
+++ b/managed/CounterStrikeSharp.API/Generated/Schema/Classes/CFuncMoveLinear.g.cs
@@ -32,11 +32,19 @@ public partial class CFuncMoveLinear : CBaseToggle
 
 	// m_soundStart
 	[SchemaMember("CFuncMoveLinear", "m_soundStart")]
-	public CGameSoundEventName SoundStart => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CFuncMoveLinear", "m_soundStart");
+	public string SoundStart
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CFuncMoveLinear", "m_soundStart"); }
+		set { Schema.SetString(this.Handle, "CFuncMoveLinear", "m_soundStart", value); }
+	}
 
 	// m_soundStop
 	[SchemaMember("CFuncMoveLinear", "m_soundStop")]
-	public CGameSoundEventName SoundStop => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CFuncMoveLinear", "m_soundStop");
+	public string SoundStop
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CFuncMoveLinear", "m_soundStop"); }
+		set { Schema.SetString(this.Handle, "CFuncMoveLinear", "m_soundStop", value); }
+	}
 
 	// m_currentSound
 	[SchemaMember("CFuncMoveLinear", "m_currentSound")]

--- a/managed/CounterStrikeSharp.API/Generated/Schema/Classes/CFuncMover.g.cs
+++ b/managed/CounterStrikeSharp.API/Generated/Schema/Classes/CFuncMover.g.cs
@@ -148,31 +148,59 @@ public partial class CFuncMover : CBaseModelEntity
 
 	// m_iszStartForwardSound
 	[SchemaMember("CFuncMover", "m_iszStartForwardSound")]
-	public CGameSoundEventName StartForwardSound => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CFuncMover", "m_iszStartForwardSound");
+	public string StartForwardSound
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CFuncMover", "m_iszStartForwardSound"); }
+		set { Schema.SetString(this.Handle, "CFuncMover", "m_iszStartForwardSound", value); }
+	}
 
 	// m_iszLoopForwardSound
 	[SchemaMember("CFuncMover", "m_iszLoopForwardSound")]
-	public CGameSoundEventName LoopForwardSound => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CFuncMover", "m_iszLoopForwardSound");
+	public string LoopForwardSound
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CFuncMover", "m_iszLoopForwardSound"); }
+		set { Schema.SetString(this.Handle, "CFuncMover", "m_iszLoopForwardSound", value); }
+	}
 
 	// m_iszStopForwardSound
 	[SchemaMember("CFuncMover", "m_iszStopForwardSound")]
-	public CGameSoundEventName StopForwardSound => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CFuncMover", "m_iszStopForwardSound");
+	public string StopForwardSound
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CFuncMover", "m_iszStopForwardSound"); }
+		set { Schema.SetString(this.Handle, "CFuncMover", "m_iszStopForwardSound", value); }
+	}
 
 	// m_iszStartReverseSound
 	[SchemaMember("CFuncMover", "m_iszStartReverseSound")]
-	public CGameSoundEventName StartReverseSound => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CFuncMover", "m_iszStartReverseSound");
+	public string StartReverseSound
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CFuncMover", "m_iszStartReverseSound"); }
+		set { Schema.SetString(this.Handle, "CFuncMover", "m_iszStartReverseSound", value); }
+	}
 
 	// m_iszLoopReverseSound
 	[SchemaMember("CFuncMover", "m_iszLoopReverseSound")]
-	public CGameSoundEventName LoopReverseSound => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CFuncMover", "m_iszLoopReverseSound");
+	public string LoopReverseSound
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CFuncMover", "m_iszLoopReverseSound"); }
+		set { Schema.SetString(this.Handle, "CFuncMover", "m_iszLoopReverseSound", value); }
+	}
 
 	// m_iszStopReverseSound
 	[SchemaMember("CFuncMover", "m_iszStopReverseSound")]
-	public CGameSoundEventName StopReverseSound => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CFuncMover", "m_iszStopReverseSound");
+	public string StopReverseSound
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CFuncMover", "m_iszStopReverseSound"); }
+		set { Schema.SetString(this.Handle, "CFuncMover", "m_iszStopReverseSound", value); }
+	}
 
 	// m_iszArriveAtDestinationSound
 	[SchemaMember("CFuncMover", "m_iszArriveAtDestinationSound")]
-	public CGameSoundEventName ArriveAtDestinationSound => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CFuncMover", "m_iszArriveAtDestinationSound");
+	public string ArriveAtDestinationSound
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CFuncMover", "m_iszArriveAtDestinationSound"); }
+		set { Schema.SetString(this.Handle, "CFuncMover", "m_iszArriveAtDestinationSound", value); }
+	}
 
 	// m_OnMovementEnd
 	[SchemaMember("CFuncMover", "m_OnMovementEnd")]

--- a/managed/CounterStrikeSharp.API/Generated/Schema/Classes/CFuncRotating.g.cs
+++ b/managed/CounterStrikeSharp.API/Generated/Schema/Classes/CFuncRotating.g.cs
@@ -64,7 +64,11 @@ public partial class CFuncRotating : CBaseModelEntity
 
 	// m_NoiseRunning
 	[SchemaMember("CFuncRotating", "m_NoiseRunning")]
-	public CGameSoundEventName NoiseRunning => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CFuncRotating", "m_NoiseRunning");
+	public string NoiseRunning
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CFuncRotating", "m_NoiseRunning"); }
+		set { Schema.SetString(this.Handle, "CFuncRotating", "m_NoiseRunning", value); }
+	}
 
 	// m_bReversed
 	[SchemaMember("CFuncRotating", "m_bReversed")]

--- a/managed/CounterStrikeSharp.API/Generated/Schema/Classes/CFuncRotator.g.cs
+++ b/managed/CounterStrikeSharp.API/Generated/Schema/Classes/CFuncRotator.g.cs
@@ -148,15 +148,27 @@ public partial class CFuncRotator : CBaseModelEntity
 
 	// m_iszStartSound
 	[SchemaMember("CFuncRotator", "m_iszStartSound")]
-	public CGameSoundEventName StartSound => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CFuncRotator", "m_iszStartSound");
+	public string StartSound
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CFuncRotator", "m_iszStartSound"); }
+		set { Schema.SetString(this.Handle, "CFuncRotator", "m_iszStartSound", value); }
+	}
 
 	// m_iszLoopSound
 	[SchemaMember("CFuncRotator", "m_iszLoopSound")]
-	public CGameSoundEventName LoopSound => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CFuncRotator", "m_iszLoopSound");
+	public string LoopSound
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CFuncRotator", "m_iszLoopSound"); }
+		set { Schema.SetString(this.Handle, "CFuncRotator", "m_iszLoopSound", value); }
+	}
 
 	// m_iszStopSound
 	[SchemaMember("CFuncRotator", "m_iszStopSound")]
-	public CGameSoundEventName StopSound => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CFuncRotator", "m_iszStopSound");
+	public string StopSound
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CFuncRotator", "m_iszStopSound"); }
+		set { Schema.SetString(this.Handle, "CFuncRotator", "m_iszStopSound", value); }
+	}
 
 	// m_flTargetAngle
 	[SchemaMember("CFuncRotator", "m_flTargetAngle")]

--- a/managed/CounterStrikeSharp.API/Generated/Schema/Classes/CFuncTrackTrain.g.cs
+++ b/managed/CounterStrikeSharp.API/Generated/Schema/Classes/CFuncTrackTrain.g.cs
@@ -84,23 +84,43 @@ public partial class CFuncTrackTrain : CBaseModelEntity
 
 	// m_iszSoundMove
 	[SchemaMember("CFuncTrackTrain", "m_iszSoundMove")]
-	public CGameSoundEventName SoundMove => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CFuncTrackTrain", "m_iszSoundMove");
+	public string SoundMove
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CFuncTrackTrain", "m_iszSoundMove"); }
+		set { Schema.SetString(this.Handle, "CFuncTrackTrain", "m_iszSoundMove", value); }
+	}
 
 	// m_iszSoundMovePing
 	[SchemaMember("CFuncTrackTrain", "m_iszSoundMovePing")]
-	public CGameSoundEventName SoundMovePing => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CFuncTrackTrain", "m_iszSoundMovePing");
+	public string SoundMovePing
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CFuncTrackTrain", "m_iszSoundMovePing"); }
+		set { Schema.SetString(this.Handle, "CFuncTrackTrain", "m_iszSoundMovePing", value); }
+	}
 
 	// m_iszSoundStart
 	[SchemaMember("CFuncTrackTrain", "m_iszSoundStart")]
-	public CGameSoundEventName SoundStart => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CFuncTrackTrain", "m_iszSoundStart");
+	public string SoundStart
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CFuncTrackTrain", "m_iszSoundStart"); }
+		set { Schema.SetString(this.Handle, "CFuncTrackTrain", "m_iszSoundStart", value); }
+	}
 
 	// m_iszSoundStop
 	[SchemaMember("CFuncTrackTrain", "m_iszSoundStop")]
-	public CGameSoundEventName SoundStop => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CFuncTrackTrain", "m_iszSoundStop");
+	public string SoundStop
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CFuncTrackTrain", "m_iszSoundStop"); }
+		set { Schema.SetString(this.Handle, "CFuncTrackTrain", "m_iszSoundStop", value); }
+	}
 
 	// m_strPathTarget
 	[SchemaMember("CFuncTrackTrain", "m_strPathTarget")]
-	public CGameSoundEventName StrPathTarget => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CFuncTrackTrain", "m_strPathTarget");
+	public string StrPathTarget
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CFuncTrackTrain", "m_strPathTarget"); }
+		set { Schema.SetString(this.Handle, "CFuncTrackTrain", "m_strPathTarget", value); }
+	}
 
 	// m_flMoveSoundMinDuration
 	[SchemaMember("CFuncTrackTrain", "m_flMoveSoundMinDuration")]

--- a/managed/CounterStrikeSharp.API/Generated/Schema/Classes/CMessage.g.cs
+++ b/managed/CounterStrikeSharp.API/Generated/Schema/Classes/CMessage.g.cs
@@ -40,7 +40,11 @@ public partial class CMessage : CPointEntity
 
 	// m_sNoise
 	[SchemaMember("CMessage", "m_sNoise")]
-	public CGameSoundEventName Noise => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CMessage", "m_sNoise");
+	public string Noise
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CMessage", "m_sNoise"); }
+		set { Schema.SetString(this.Handle, "CMessage", "m_sNoise", value); }
+	}
 
 	// m_OnShowMessage
 	[SchemaMember("CMessage", "m_OnShowMessage")]

--- a/managed/CounterStrikeSharp.API/Generated/Schema/Classes/CPhysConstraint.g.cs
+++ b/managed/CounterStrikeSharp.API/Generated/Schema/Classes/CPhysConstraint.g.cs
@@ -64,7 +64,11 @@ public partial class CPhysConstraint : CLogicalEntity
 
 	// m_breakSound
 	[SchemaMember("CPhysConstraint", "m_breakSound")]
-	public CGameSoundEventName BreakSound => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "CPhysConstraint", "m_breakSound");
+	public string BreakSound
+	{
+		get { return Schema.GetUtf8String(this.Handle, "CPhysConstraint", "m_breakSound"); }
+		set { Schema.SetString(this.Handle, "CPhysConstraint", "m_breakSound", value); }
+	}
 
 	// m_forceLimit
 	[SchemaMember("CPhysConstraint", "m_forceLimit")]

--- a/managed/CounterStrikeSharp.API/Generated/Schema/Classes/locksound_t.g.cs
+++ b/managed/CounterStrikeSharp.API/Generated/Schema/Classes/locksound_t.g.cs
@@ -20,11 +20,19 @@ public partial class locksound_t : NativeObject
 
 	// sLockedSound
 	[SchemaMember("locksound_t", "sLockedSound")]
-	public CGameSoundEventName SLockedSound => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "locksound_t", "sLockedSound");
+	public string SLockedSound
+	{
+		get { return Schema.GetUtf8String(this.Handle, "locksound_t", "sLockedSound"); }
+		set { Schema.SetString(this.Handle, "locksound_t", "sLockedSound", value); }
+	}
 
 	// sUnlockedSound
 	[SchemaMember("locksound_t", "sUnlockedSound")]
-	public CGameSoundEventName SUnlockedSound => Schema.GetDeclaredClass<CGameSoundEventName>(this.Handle, "locksound_t", "sUnlockedSound");
+	public string SUnlockedSound
+	{
+		get { return Schema.GetUtf8String(this.Handle, "locksound_t", "sUnlockedSound"); }
+		set { Schema.SetString(this.Handle, "locksound_t", "sUnlockedSound", value); }
+	}
 
 	// flwaitSound
 	[SchemaMember("locksound_t", "flwaitSound")]

--- a/managed/CounterStrikeSharp.SchemaGen/Program.cs
+++ b/managed/CounterStrikeSharp.SchemaGen/Program.cs
@@ -46,6 +46,7 @@ internal static partial class Program
         "CUtlOrderedMap",
         "CAnimGraph2ParamOptionalRef",
         "CUtlHashtable",
+        "CUtlDict",
         "CSmartPtr",
         "CUtlLeanVector",
         "CUtlBinaryBlock",

--- a/managed/CounterStrikeSharp.SchemaGen/SchemaFieldType.cs
+++ b/managed/CounterStrikeSharp.SchemaGen/SchemaFieldType.cs
@@ -95,7 +95,7 @@ public record SchemaFieldType
         {
             SchemaAtomicCategory.Basic => name switch
             {
-                "CUtlString" or "CUtlSymbolLarge" or "CGlobalSymbol" or "CEntityNameString" => "string",
+                "CUtlString" or "CUtlSymbolLarge" or "CGlobalSymbol" or "CEntityNameString" or "CGameSoundEventName" => "string",
                 "CEntityHandle" => "CHandle<CEntityInstance>",
                 "CNetworkedQuantizedFloat" => "float",
                 "RotationVector" => "Vector",


### PR DESCRIPTION
Schema 1.41.6.8 changed sound-name fields from atomic CUtlSymbolLarge to new atomic CGameSoundEventName (still an 8-byte string symbol) and added CUtlDict<GameTime_t> members in CAI_Expresser. SchemaGen's atomic catch-all emitted both as GetDeclaredClass<T>, referencing C# types that don't exist -> 46 CS0246 build errors in Generated/Schema.

- SchemaFieldType: CGameSoundEventName -> string (GetUtf8String/SetString, same as pre-1.41.6.8 CUtlSymbolLarge behavior).
- Program: add CUtlDict to IgnoreClassWildcards (no C# wrapper; joins CUtlOrderedMap/CUtlHashtable). Skips the CAI_Expresser fields.
- Regenerated Generated/Schema/Classes; API builds with 0 errors.