### PR TITLE
fix: isolate spdlog symbols to stop RayTrace logger crash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,16 @@ if(LINUX)
                           PREFIX ""
                           LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/addons/counterstrikesharp/bin/linuxsteamrt64"
     )
+
+    # Localize every symbol except the two the outside world resolves by name.
+    # spdlog is header-only and compiles a global logger-registry singleton into
+    # this .so; with default ELF visibility that singleton is exported and the
+    # dynamic linker merges it with the CS2 server's own spdlog registry. The
+    # engine then re-registers its "RayTrace" logger into our already-populated
+    # registry -> spdlog_ex "logger ... already exists" -> std::terminate.
+    # The version script keeps our spdlog (and dyncall/protobuf/sdk) private.
+    target_link_options(${PROJECT_NAME} PRIVATE
+                        "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/makefiles/exports.ver")
 elseif(WIN32)
     include("makefiles/windows.base.cmake")
     set_target_properties(${PROJECT_NAME} PROPERTIES

--- a/makefiles/exports.ver
+++ b/makefiles/exports.ver
@@ -1,0 +1,22 @@
+# Linker version script for counterstrikesharp.so (ELF / Linux).
+#
+# Without this, every symbol compiled into the .so keeps default visibility and
+# lands in the dynamic symbol table (4000+ symbols: spdlog, dyncall, protobuf,
+# sdk, ...). The dynamic linker then interposes those globals against the CS2
+# server's OWN copies of the same libraries. spdlog is header-only, so its
+# global logger registry singleton gets merged with the engine's -- the engine
+# registers its "RayTrace" logger into a registry we already populated, spdlog
+# throws `spdlog_ex("logger with name 'RayTrace' already exists")`, and the
+# uncaught exception aborts the server via std::terminate.
+#
+# Exporting ONLY the two symbols the outside world resolves by name keeps our
+# spdlog (and everything else) private, so no registry is ever shared:
+#   CreateInterface -- Metamod's plugin entry point.
+#   InvokeNative    -- managed P/Invoke target ([DllImport EntryPoint="InvokeNative"]).
+{
+    global:
+        CreateInterface;
+        InvokeNative;
+    local:
+        *;
+};


### PR DESCRIPTION
## Problem

Server aborts on startup/map load:

```
terminate called after throwing an instance of 'spdlog::spdlog_ex'
  what():  logger with name 'RayTrace' already exists
```

`RayTrace` is the **CS2 engine's** own spdlog logger, not ours.

## Root cause

`counterstrikesharp.so` exported all **4107** of its symbols with default ELF visibility — including spdlog's header-only global logger registry (1123 spdlog symbols). The dynamic linker interposed our registry singleton against the CS2 server's own spdlog copy, merging them into one shared registry. When the engine registered its `RayTrace` logger it hit our already-populated registry → `throw_if_exists_` → `spdlog_ex` → uncaught → `std::terminate`.

## Fix

Add a linker version script (`makefiles/exports.ver`) exporting **only** the two symbols the outside world resolves by name, localizing everything else:

- `CreateInterface` — Metamod plugin entry point
- `InvokeNative` — managed P/Invoke target (`[DllImport(EntryPoint="InvokeNative")]`)

Our spdlog, dyncall, protobuf and sdk symbols are now private, so no registry is ever shared. Wired via `target_link_options` in the `if(LINUX)` block.

Linux-only — Windows PE has no global symbol interposition, so it was never affected.

## Verification

Exported defined symbols before/after a clean rebuild:

| | exported (T/W) | spdlog symbols |
|---|---|---|
| before | 4107 | 1123 |
| after | **2** | **0** |

```
$ nm -D counterstrikesharp.so | grep -E ' [TW] '
000000000029a710 T CreateInterface
0000000000043a77 T InvokeNative
```

Verified at link/symbol level. Not yet run on a live server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)